### PR TITLE
feat: migrate to GitHub Container Registry with CI/CD

### DIFF
--- a/.github/workflows/check-base-image.yml
+++ b/.github/workflows/check-base-image.yml
@@ -1,0 +1,64 @@
+name: Check Base Image Update
+
+on:
+  schedule:
+    # Check daily at 04:00 UTC
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-and-rebuild:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get current Alpine digest
+        id: alpine
+        run: |
+          CURRENT=$(grep -oP 'FROM alpine:\K.*' gitolite-cgit/Dockerfile || echo "latest")
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+
+          # Get the latest Alpine digest from Docker Hub
+          LATEST_DIGEST=$(docker manifest inspect alpine:latest 2>/dev/null | jq -r '.manifests[0].digest' || echo "")
+          echo "latest_digest=${LATEST_DIGEST}" >> "$GITHUB_OUTPUT"
+
+          # Get the digest we last built with (stored in a file)
+          if [ -f .alpine-digest ]; then
+            LAST_DIGEST=$(cat .alpine-digest)
+          else
+            LAST_DIGEST=""
+          fi
+          echo "last_digest=${LAST_DIGEST}" >> "$GITHUB_OUTPUT"
+
+          if [ "$LATEST_DIGEST" != "$LAST_DIGEST" ] && [ -n "$LATEST_DIGEST" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "$LATEST_DIGEST" > .alpine-digest
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit digest change and trigger rebuild
+        if: steps.alpine.outputs.updated == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .alpine-digest
+          git commit -m "chore: update Alpine base image digest" || true
+          git push
+
+      - name: Trigger Docker rebuild
+        if: steps.alpine.outputs.updated == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker.yml',
+              ref: 'main'
+            })

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gitolite-cgit/**'
+      - '.github/workflows/docker.yml'
+  schedule:
+    # Rebuild weekly (Monday 06:00 UTC) to pick up Alpine base image updates
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./gitolite-cgit
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## What is this image?
 
-[`bacnh85/gitolite-cgit`](https://hub.docker.com/r/bacnh85/gitolite-cgit) is a Docker image with `cgit` and `gitolite` running on top of `alpine` base image. Dockerfile is available at [Github repo](https://github.com/bacnh85/docker-gitolite-cgit).
+[`ghcr.io/bacnh85/docker-gitolite-cgit`](https://github.com/bacnh85/docker-gitolite-cgit/pkgs/container/docker-gitolite-cgit) is a Docker image with `cgit` and `gitolite` running on top of `alpine` base image. Dockerfile is available at [Github repo](https://github.com/bacnh85/docker-gitolite-cgit).
+
+[![Build and Push Docker Image](https://github.com/bacnh85/docker-gitolite-cgit/actions/workflows/docker.yml/badge.svg)](https://github.com/bacnh85/docker-gitolite-cgit/actions/workflows/docker.yml)
 
 ![cgit](img/cgit.png)
 
@@ -11,13 +13,13 @@
 1. Pull the image
 
 ```
-docker pull bacnh85/gitolite-cgit
+docker pull ghcr.io/bacnh85/docker-gitolite-cgit:latest
 ```
 
 2. Run the image with provided environment:
 
 ```
-docker run -e SSH_KEY="$(cat ~/.ssh/id_rsa.pub)" -e SSH_KEY_NAME="$(whoami)" -p 22:22 -p 80:80 -p 9418:9418 -v repo:/var/lib/git/ bacnh85/gitolite-cgit
+docker run -e SSH_KEY="$(cat ~/.ssh/id_rsa.pub)" -e SSH_KEY_NAME="$(whoami)" -p 22:22 -p 80:80 -p 9418:9418 -v repo:/var/lib/git/ ghcr.io/bacnh85/docker-gitolite-cgit:latest
 ```
 
 ### Environment
@@ -51,7 +53,7 @@ Supported clone method:
 1. Pull the image:
 
 ```
-docker pull bacnh85/gitolite-cgit
+docker pull ghcr.io/bacnh85/docker-gitolite-cgit:latest
 ```
 
 2. Create environment file
@@ -91,7 +93,7 @@ version: '3'
 
 services:
   app:
-    image: bacnh85/gitolite-cgit
+    image: ghcr.io/bacnh85/docker-gitolite-cgit:latest
     container_name: gitolite-cgit
     env_file: config.env
     volumes: 
@@ -125,7 +127,7 @@ version: '3'
 
 services:
   app:
-    image: bacnh85/gitolite-cgit
+    image: ghcr.io/bacnh85/docker-gitolite-cgit:latest
     container_name: gitolite-cgit
     env_file: config.env
     volumes: 
@@ -145,6 +147,27 @@ volumes:
 ```
 git clone https://github.com/bacnh85/docker-gitolite-cgit.git
 cd docker-gitolite-cgit
-docker build gitolite-cgit -t bacnh85/gitolite-cgit
+docker build gitolite-cgit -t ghcr.io/bacnh85/docker-gitolite-cgit:latest
 ```
 
+## CI/CD
+
+This repository uses GitHub Actions to automatically build and publish the Docker image to [GitHub Container Registry (ghcr.io)](https://github.com/bacnh85/docker-gitolite-cgit/pkgs/container/docker-gitolite-cgit).
+
+### Triggers
+
+| Trigger | Description |
+|---------|-------------|
+| Push to `main` | Builds when files in `gitolite-cgit/` or workflow files change |
+| Weekly schedule | Rebuilds every Monday at 06:00 UTC to pick up Alpine base image updates |
+| Daily check | Checks if the Alpine base image has been updated and triggers a rebuild if needed |
+| Manual (`workflow_dispatch`) | Trigger a build on demand from the Actions tab |
+
+### Multi-architecture
+
+Images are built for both `linux/amd64` and `linux/arm64` platforms.
+
+### Available tags
+
+- `latest` — always points to the latest build from `main`
+- `sha-<commit>` — tagged with the short commit SHA for reproducibility

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    image: bacnh85/gitolite-cgit
+    image: ghcr.io/bacnh85/docker-gitolite-cgit:latest
     container_name: gitolite-cgit
     env_file: config.env
     volumes:

--- a/gitolite-cgit/Dockerfile
+++ b/gitolite-cgit/Dockerfile
@@ -1,4 +1,4 @@
-# docker build . -t bacnh85/gitolite-cgit
+# docker build . -t ghcr.io/bacnh85/docker-gitolite-cgit
 FROM alpine:latest
 LABEL MAINTAINER="mail@bacnh.com"
 


### PR DESCRIPTION
## Summary

Migrate Docker image publishing from Docker Hub to **GitHub Container Registry (ghcr.io)** with automated CI/CD pipelines.

### Changes

**CI/CD Workflows (new)**
- `docker.yml` — Builds and pushes multi-arch (`linux/amd64` + `linux/arm64`) image to ghcr.io
  - Triggers: push to `main` (path-filtered), weekly Monday 06:00 UTC, manual dispatch
  - Tags: `latest` + `sha-<commit>` for reproducibility
  - Uses GitHub Actions cache for Docker layers
- `check-base-image.yml` — Daily check (04:00 UTC) for Alpine base image updates
  - Compares current digest vs last-built digest
  - If changed: commits new digest and triggers `docker.yml` rebuild

**Registry Migration**
| File | Before | After |
|------|--------|-------|
| Dockerfile | `bacnh85/gitolite-cgit` | `ghcr.io/bacnh85/docker-gitolite-cgit` |
| docker-compose.yml | `bacnh85/gitolite-cgit` | `ghcr.io/bacnh85/docker-gitolite-cgit:latest` |
| README.md | Docker Hub links | ghcr.io links + CI/CD docs |

**README Updates**
- All `docker pull`, `docker run`, and `docker build` examples updated
- Added CI/CD section documenting triggers, multi-arch support, and available tags
- Added build status badge

## Test Plan
- [ ] Verify GitHub Actions workflow triggers on merge
- [ ] Confirm image appears at ghcr.io/bacnh85/docker-gitolite-cgit
- [ ] Test pulling the image on both amd64 and arm64 hosts
- [ ] Verify daily base image check runs without errors